### PR TITLE
Enlarge COP and RIR/ITCV plots in Shiny app

### DIFF
--- a/calculations-cop.R
+++ b/calculations-cop.R
@@ -259,7 +259,7 @@ get_cop_results <- function(input_cop) {
     list(
       text = cop_output,
       plot = raw_calc$Figure +
-        ggplot2::theme(text = ggplot2::element_text(size = 15)),
+        ggplot2::theme(text = ggplot2::element_text(size = 20)),
       raw = r_output
     )
   

--- a/calculations-rir-itcv.R
+++ b/calculations-rir-itcv.R
@@ -616,7 +616,8 @@ get_rir_itcv_results <- function(input_linear) {
   linear_results <-
     list(
       text = linear_output,
-      plot = linear_plot,
+      plot = linear_plot +
+        ggplot2::theme(text = ggplot2::element_text(size = 18)),
       raw = r_output
     )
   


### PR DESCRIPTION
Add theme(text=) size override to COP and RIR/ITCV plot returns for larger, more legible plot text.